### PR TITLE
[Styles] Update Responsive for Download Page (375px)

### DIFF
--- a/components/Download.tsx
+++ b/components/Download.tsx
@@ -60,8 +60,8 @@ const Download: FC = () => {
   return (
     <section id="download" className="text-center py-20 mx-16">
       <h2 className="text-3xl font-bold sm:text-6xl">ดาวน์โหลด</h2>
-      <div className="flex flex-wrap mt-8">
-        <div className="shadow-lg mx-auto w-64">
+      <div className="flex flex-wrap mt-8 gap-8 justify-evenly">
+        <div className="shadow-lg w-64">
           <a
             href="https://github.com/Manoonchai/Manoonchai/releases/download/v1.0/Manoonchai.keylayout"
             target="_blank"
@@ -75,7 +75,7 @@ const Download: FC = () => {
             </div>
           </a>
         </div>
-        <div className="shadow-lg mx-auto w-64">
+        <div className="shadow-lg w-64">
           <a
             href="https://github.com/Manoonchai/Manoonchai/releases/download/v1.0/Manoonchai.zip"
             target="_blank"
@@ -89,7 +89,7 @@ const Download: FC = () => {
             </div>
           </a>
         </div>
-        <div className="shadow-lg mx-auto w-64">
+        <div className="shadow-lg w-64">
           <a
             href="https://github.com/Manoonchai/Manoonchai/releases/download/v1.0/Manoonchai_xkb"
             target="_blank"


### PR DESCRIPTION
# Scope of work
I've seen the Download page doesn't work properly on mobile or 375px screen.
So, I have update overflow scrolling to `<code>` and implement gap.

If you have any feedback or suggestion, please do not hesitate to reply on this PR.

# Screenshots

- Before
![image](https://user-images.githubusercontent.com/6861191/139293376-56c1a626-0430-4fd5-8b7e-dea87d07a4ee.png)

- After
![image](https://user-images.githubusercontent.com/6861191/139293474-a3c37f96-7912-4acc-a6ff-a9dc761b7db2.png)

